### PR TITLE
Fix/parsing

### DIFF
--- a/src/Expr.hs
+++ b/src/Expr.hs
@@ -1,19 +1,6 @@
 module Expr where
 import Types
 
-data Program
-    = Program { getProgram :: [Stmt] }
-    deriving Show
-
-data Stmt
-    = StDef Def
-    | StExp Expr
-    deriving Show
-
-data Def
-    = Def Id Type Expr
-    deriving Show
-
 data Param
     = Param Id Type
     deriving Show
@@ -34,8 +21,9 @@ data Expr
     | ApolloNote Pitch Duration
     | ApolloChord [Pitch] Duration
     | ApolloList [Expr]
+    | Def Id Type Expr
     | Name Id
-    | Block [Stmt] Expr
+    | Block [Expr] Expr
     | Cond Expr Expr Expr
     | FnCall Id [Expr]
     -- Unary Operators
@@ -68,7 +56,7 @@ typeOf (ApolloBool _) = "Boolean"
 typeOf (ApolloList _) = "List"
 typeOf todoVal        = "TODO: `typeOf` for " ++ show todoVal
 
-define :: Id -> Type -> Expr -> Def
+define :: Id -> Type -> Expr -> Expr
 -- Coerce Int to Pitch
 define i (Data "Pitch") (ApolloInt p)
     | p < 0 || p > 127  = error "Pitch out of range [0, 127]"

--- a/src/Expr.hs
+++ b/src/Expr.hs
@@ -43,12 +43,14 @@ data Expr
     | GEq Expr Expr     -- >=
     | And Expr Expr     -- &&
     | Or Expr Expr      -- ||
+    deriving Show
 
-instance Show Expr where
-  show (ApolloInt  i) = show i
-  show (ApolloBool b) = show b
-  show (ApolloList l) = show l
-  show otherVal       = show otherVal
+showVal :: Expr -> String
+showVal (ApolloInt  i) = show i
+showVal (ApolloBool b) = show b
+showVal (ApolloList l) = "[" ++ commaDelim l  ++ "]"
+  where commaDelim = init . concatMap ((++ ",") . showVal)
+showVal otherVal       = show otherVal
 
 typeOf :: Expr -> String
 typeOf (ApolloInt _)  = "Integer"

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -30,7 +30,7 @@ showResults :: [ThrowsError Expr] -> String
 showResults = concatMap ((++ "\n") . showResult)
 
 showResult :: ThrowsError Expr -> String
-showResult = extractValue . trapError . liftM show
+showResult = extractValue . trapError . liftM showVal
 
 
 -- Read-Evaluate-print Loop -------------------------------------------------

--- a/src/Parse.y
+++ b/src/Parse.y
@@ -35,7 +35,7 @@ import Types
     '!'         { TokenNot }
     '='         { TokenDef }
     '->'        { TokenArrow }
-    ':'         { TokenColon } 
+    ':'         { TokenColon }
     ','         { TokenComma }
     '('         { TokenLParen }
     ')'         { TokenRParen }
@@ -54,16 +54,11 @@ import Types
 
 %%
 
-Program     : Statements                    { Program $1 }
-
 Statements  : Statement                     { [$1] }
             | Statement Statements          { $1:$2 }
 
-Statement   : Definition                    { StDef $1 }
-            | Expression                    { StExp $1 }
-
-Definitions : Definition                    { [$1] }
-            | Definition Definitions        { $1:$2 }
+Statement   : Definition                    { $1 }
+            | Expression                    { $1 }
 
 Definition  : ID ':' Type '=' Expression    { define $1 $3 $5 }
 
@@ -97,12 +92,12 @@ Expression  : NUM                           { ApolloInt $1 }
             | Block                         { $1 }
             | '(' Expression ')'            { $2 }
 
-Conditional : CASE '(' Expression ')' 
-                Expression 
-              OTHERWISE 
+Conditional : CASE '(' Expression ')'
+                Expression
+              OTHERWISE
                 Expression                  { Cond $3 $5 $7 }
-            | CASE '(' Expression ')' 
-                Expression 
+            | CASE '(' Expression ')'
+                Expression
               Conditional                   { Cond $3 $5 $6 }
 
 UnOp        : '-' Expression  %prec NEG     { Neg $2 }
@@ -130,13 +125,5 @@ parseError :: [Token] -> a
 parseError = error "Parse error"
 
 parse :: String -> [Expr]
-parse = map getExpr . getProgram . program . scanTokens
-
--- Becuase `apollo` cannot yet handle defs, this fn
--- is used deconstruct a statement and ensure no defs are found
--- TODO: fix!
-
-getExpr :: Stmt -> Expr
-getExpr (StExp e) = e
-getExpr (StDef d) = error $ "TODO: not yet able to handle Defs (" ++ show d ++ ")"
+parse = program . scanTokens
 }


### PR DESCRIPTION
Fixes #4.

Also unified the `Def` and `Expr` types and removed the `Program` type. PR'd since I want to double check with everyone that this won't cause problems.

(@javierllaca, any reason not to unify? Working on symtab now; `eval` will also handle `Def`s.)
